### PR TITLE
Avoid rule overwriting and include rules having an empty right side

### DIFF
--- a/pyfpgrowth/pyfpgrowth.py
+++ b/pyfpgrowth/pyfpgrowth.py
@@ -263,7 +263,7 @@ def generate_association_rules(patterns, confidence_threshold):
     for itemset in patterns.keys():
         upper_support = patterns[itemset]
 
-        for i in range(1, len(itemset)):
+        for i in range(1, len(itemset) + 1):
             for antecedent in itertools.combinations(itemset, i):
                 antecedent = tuple(sorted(antecedent))
                 consequent = tuple(sorted(set(itemset) - set(antecedent)))

--- a/pyfpgrowth/pyfpgrowth.py
+++ b/pyfpgrowth/pyfpgrowth.py
@@ -257,7 +257,7 @@ def generate_association_rules(patterns, confidence_threshold):
     """
     Given a set of frequent itemsets, return a dict
     of association rules in the form
-    {(left): ((right), confidence)}
+    {(left, right): (support, confidence)}
     """
     rules = {}
     for itemset in patterns.keys():
@@ -273,6 +273,6 @@ def generate_association_rules(patterns, confidence_threshold):
                     confidence = float(upper_support) / lower_support
 
                     if confidence >= confidence_threshold:
-                        rules[antecedent] = (consequent, confidence)
+                        rules[(antecedent, consequent)] = (upper_support, confidence)
 
     return rules

--- a/tests/test_pyfpgrowth.py
+++ b/tests/test_pyfpgrowth.py
@@ -9,6 +9,8 @@ Tests for pyfpgrowth` module.
 """
 
 import unittest
+from itertools import chain, combinations
+
 from pyfpgrowth import *
 from pyfpgrowth.pyfpgrowth import FPNode, FPTree
 
@@ -71,34 +73,54 @@ class FPTreeTests(unittest.TestCase):
 class FPGrowthTests(unittest.TestCase):
     """
     Tests everything together.
+
+    Example is taken from [Agrawal1994]_.
+
+    .. [Agrawal1994] Rakesh Agrawal and Ramakrishnan Srikant. 1994. Fast Algorithms for
+       Mining Association Rules in Large Databases. In Proceedings of the 20th
+       International Conference on Very Large Data Bases (VLDB '94), Jorge B. Bocca,
+       Matthias Jarke, and Carlo Zaniolo (Eds.). Morgan Kaufmann Publishers Inc., San
+       Francisco, CA, USA, 487-499.
     """
     support_threshold = 2
-    transactions = [[1, 2, 5],
-                    [2, 4],
-                    [2, 3],
-                    [1, 2, 4],
-                    [1, 3],
-                    [2, 3],
-                    [1, 3],
-                    [1, 2, 3, 5],
-                    [1, 2, 3]]
+    transactions = [
+        [1, 3, 4],
+        [2, 3, 5],
+        [1, 2, 3, 5],
+        [2, 5]
+    ]
+    expected_frequent_item_sets = {(1,): 2, (2,): 3, (3,): 3, (5,): 3, (1, 3): 2, (2, 3): 2, (2, 5): 3, (3, 5): 2,
+                                   (2, 3, 5): 2}
 
     def test_find_frequent_patterns(self):
         patterns = find_frequent_patterns(self.transactions, self.support_threshold)
 
-        expected = {(1, 2): 4, (1, 2, 3): 2, (1, 3): 4, (1,): 6, (2,): 7, (2, 4): 2,
-                    (1, 5): 2, (5,): 2, (2, 3): 4, (2, 5): 2, (4,): 2, (1, 2, 5): 2}
-        self.assertEqual(patterns, expected)
+        self.assertDictEqual(patterns, self.expected_frequent_item_sets)
 
     def test_generate_association_rules(self):
-        patterns = find_frequent_patterns(self.transactions, self.support_threshold)
-        rules = generate_association_rules(patterns, 0.7)
+        confidence_threshold = 0.1
 
-        expected = {(1, 5): ((2,), 1.0), (5,): ((1, 2), 1.0),
-                    (2, 5): ((1,), 1.0), (4,): ((2,), 1.0)}
-        self.assertEqual(rules, expected)
+        def get_non_empty_subsets(iterable):
+            """Return all non empty subsets of ``iterable`` including ``iterable`` itself."""
+            s = list(iterable)
+            return chain.from_iterable(combinations(s, r) for r in range(1, len(s) + 1))
+
+        expected = {}
+        for frequent_item in self.expected_frequent_item_sets:
+            for left_side in get_non_empty_subsets(frequent_item):
+                support = self.expected_frequent_item_sets[frequent_item]
+                support_of_left_side = self.expected_frequent_item_sets[left_side]
+                right_side = tuple(sorted(set(frequent_item) - set(left_side)))
+                confidence = self.expected_frequent_item_sets[frequent_item] / support_of_left_side
+
+                if confidence >= confidence_threshold:
+                    expected[(left_side, right_side)] = (support, confidence)
+
+        association_rules = generate_association_rules(self.expected_frequent_item_sets, confidence_threshold)
+        self.assertDictEqual(expected, association_rules)
 
 
 if __name__ == '__main__':
     import sys
+
     sys.exit(unittest.main())


### PR DESCRIPTION
This pull request aims to close issues #3, #6, #11, #12 and #15.

The function `generate_association_rules(...)` is revised in the following ways:
1. The return value is changed to a *dictionary* of the form
   `{(left_side, right_side): (support, confidence)}`.
   This (a) avoids rule overwriting and (b) includes the support in the rules.
2. The generated rules now also contain rules having an empty right side
   as, to the best of my knowledge, is required for a correct implementation of the algorithm.

The unit tests are adapted to these changes. They now verify that this implementation produces the correct result for an example taken from the original paper describing the Apriori algorithm.

I want to add that I am very confident that this implementation is correct and it seems reasonably fast:

1. I compared the result produced by this implementation on a large
   production data set with the result produced by an implementation of the
   Apriori algorithm I used previously. Both results were identical.
2. This implementation was significantly faster than the implementation of the Apriori algorithm.

Thank you @evandempsey.