### PR TITLE
Missing patterns resolved.

### DIFF
--- a/pyfpgrowth/pyfpgrowth.py
+++ b/pyfpgrowth/pyfpgrowth.py
@@ -152,7 +152,12 @@ class FPTree(object):
         if self.tree_has_single_path(self.root):
             return self.generate_pattern_list()
         else:
-            return self.zip_patterns(self.mine_sub_trees(threshold))
+            patterns = self.zip_patterns(self.mine_sub_trees(threshold))
+            if tuple([self.root.value]) not in patterns and self.root.value != None:
+                patterns[tuple([self.root.value])] = self.root.count
+
+        return patterns
+
 
     def zip_patterns(self, patterns):
         """


### PR DESCRIPTION
In fpgrowth.find_frequent_patterns function failed to get all patterns. So, changes in this code will get expected output. eg: In below example, transactions = [[1, 2, 5],
                [2, 4],
                [2, 3],
                [1, 2, 4],
                [1, 4],
                [2, 3],
                [1, 3],
                [1, 2, 3, 5],
                [1, 2, 3]]
(4,):3 should be present in patterns, but it doesn't, my changes will give exact output.