### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -26,7 +26,7 @@ Use generate_association_rules to find patterns that are associated with another
 
     rules = pyfpgrowth.generate_association_rules(patterns, 0.7)
 
-The FP-Growth algorithm uses a recursive implementation, so it is possible that if you feed a large transation set
+The FP-Growth algorithm uses a recursive implementation, so it is possible that if you feed a large transaction set
 into find_frequent_patterns you will see a 'maximum recursion depth exceeded' error. If you do, you can modify your recursion limit::
 
     import sys


### PR DESCRIPTION
## Summary
- fix a spelling error in the usage documentation

## Testing
- `make test`