### PR TITLE
Update Python version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.5-dev" # 3.5 development branch
-  - "nightly" # currently points to 3.6-dev
+  - "3.11"
+  - "3.12"
 
 # command to install dependencies
 install: "pip install -r requirements.txt"

--- a/setup.py
+++ b/setup.py
@@ -46,13 +46,13 @@ setup(
         'License :: OSI Approved :: ISC License (ISCL)',
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
+    python_requires='>=2.7',
     test_suite='tests',
     tests_require=test_requirements
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist = py27, py311, py312
 
 [testenv]
 setenv =


### PR DESCRIPTION
## Summary
- update supported Python versions in setuptools metadata
- limit tox and Travis configurations to the latest Python 2 and 3 releases

## Testing
- `python3 setup.py test`