### PR TITLE
Support multiple association rules per antecedent

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,8 @@ Use generate_association_rules to find patterns that are associated with another
 
     rules = pyfpgrowth.generate_association_rules(patterns, 0.7)
 
+``rules`` maps each antecedent to a list of ``(consequent, confidence)`` tuples.
+
 Credits
 ---------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -26,6 +26,8 @@ Use generate_association_rules to find patterns that are associated with another
 
     rules = pyfpgrowth.generate_association_rules(patterns, 0.7)
 
+``rules`` maps each antecedent to a list of ``(consequent, confidence)`` tuples.
+
 The FP-Growth algorithm uses a recursive implementation, so it is possible that if you feed a large transaction set
 into find_frequent_patterns you will see a 'maximum recursion depth exceeded' error. If you do, you can modify your recursion limit::
 

--- a/pyfpgrowth/pyfpgrowth.py
+++ b/pyfpgrowth/pyfpgrowth.py
@@ -224,9 +224,9 @@ def find_frequent_patterns(
 
 def generate_association_rules(
     patterns: Dict[Tuple[Any, ...], int], confidence_threshold: float
-) -> Dict[Tuple[Any, ...], Tuple[Tuple[Any, ...], float]]:
-    """Return association rules with confidence >= ``confidence_threshold``."""
-    rules: Dict[Tuple[Any, ...], Tuple[Tuple[Any, ...], float]] = {}
+) -> Dict[Tuple[Any, ...], List[Tuple[Tuple[Any, ...], float]]]:
+    """Return rules grouped by antecedent with confidence >= ``confidence_threshold``."""
+    rules: Dict[Tuple[Any, ...], List[Tuple[Tuple[Any, ...], float]]] = {}
     for itemset, upper_support in patterns.items():
         for i in range(1, len(itemset)):
             for antecedent in itertools.combinations(itemset, i):
@@ -238,6 +238,8 @@ def generate_association_rules(
                     confidence = upper_support / float(lower_support)
 
                     if confidence >= confidence_threshold:
-                        rules[antecedent] = (consequent, confidence)
+                        rules.setdefault(antecedent, []).append(
+                            (consequent, confidence)
+                        )
 
     return rules

--- a/tests/test_pyfpgrowth.py
+++ b/tests/test_pyfpgrowth.py
@@ -94,8 +94,12 @@ class FPGrowthTests(unittest.TestCase):
         patterns = find_frequent_patterns(self.transactions, self.support_threshold)
         rules = generate_association_rules(patterns, 0.7)
 
-        expected = {(1, 5): ((2,), 1.0), (5,): ((1, 2), 1.0),
-                    (2, 5): ((1,), 1.0), (4,): ((2,), 1.0)}
+        expected = {
+            (5,): [((1,), 1.0), ((2,), 1.0), ((1, 2), 1.0)],
+            (1, 5): [((2,), 1.0)],
+            (2, 5): [((1,), 1.0)],
+            (4,): [((2,), 1.0)],
+        }
         self.assertEqual(rules, expected)
 
 


### PR DESCRIPTION
## Summary
- allow multiple consequents in `generate_association_rules`
- document new rule structure in README and usage docs
- adjust unit test for new return structure

## Testing
- `python setup.py test`
- `flake8 pyfpgrowth tests` *(fails: command not found)*
- `make -C docs html` *(fails: sphinx-build not found)*